### PR TITLE
`buildroot`: Use https:// instead of git:// protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	branch = master
 [submodule "buildroot"]
 	path = buildroot
-	url = git://git.buildroot.net/buildroot
+	url = https://github.com/buildroot/buildroot.git
 [submodule "vitetris"]
 	path = vitetris
 	url = https://github.com/pulp-platform/vitetris.git


### PR DESCRIPTION
The submodule update of `buildroot` regularly crashes, especially during bender checkouts. This is most likely due to the use git:// of the git protocol. Changing the remote to https://github.com/pulp-platform/cva6-sdk solves this issue. I have seen a couple of commits of people doing the same, but it never got merged so far.